### PR TITLE
Obsidian taskify

### DIFF
--- a/plugins/community/obsidian-taskify/index.ts
+++ b/plugins/community/obsidian-taskify/index.ts
@@ -1,0 +1,51 @@
+function formatISODate(date: Date): string {
+    const year = date.getFullYear();
+    const month = (date.getMonth() + 1).toString().padStart(2, '0');
+    const day = date.getDate().toString().padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}
+
+export default async (request: Request): Promise<Response> => {
+    const json = await request.json();
+    const note = json['note'];
+    const content: string = note?.content || "";
+    let today = new Date();
+    let todayISO = formatISODate(today);
+
+    // Step through each line in content and look for checkboxes
+    const lines = content.split('\n');
+    const newlines : string[] = [];
+    for (let line of lines) {
+        console.log('line = ' + line);
+        let newline = '';
+        if (line.startsWith('- [ ] ')) {
+            // Look for the ➕ emoji.  If it is not in line, we need to format the line.
+            if (!line.includes('➕')) {
+                // Get the text after the checkbox
+                const text = line.substring(6);
+
+                // If text ends with a date in the format YYYY-MM-DD, then we need to split
+                // the line into two lines, one with the date and one with the text.
+                const dateRegex = /\d{4}-\d{2}-\d{2}/;
+                const dateMatch = text.match(dateRegex);
+                if (dateMatch) {
+                    const date = dateMatch[0];
+                    const textWithoutDate = text.replace(date, '').trim();
+                    newline = `- [ ] ${textWithoutDate} ➕ ${todayISO} 📅 ${date}`;
+                } else {
+                    newline = `- [ ] ${text} ➕ ${todayISO}`;
+                }
+                console.log('Pushing newline = ' + newline);
+                newlines.push(newline);
+            } else {
+                // Just add the current line to the newlines array
+                console.log('Pushing line = ' + line);
+                newlines.push(line);
+            }
+        }
+    }
+    const newcontent = newlines.join('\n');
+    note.content = newcontent;
+    console.log('note = ' + JSON.stringify(note));
+    return new Response(JSON.stringify(note));
+};

--- a/plugins/community/obsidian-taskify/index.ts
+++ b/plugins/community/obsidian-taskify/index.ts
@@ -1,3 +1,6 @@
+// Fleeting Notes plugin to convert simple checkbox tasks to Obsidian Task format
+// kjarnot - 2024-01-28
+
 function formatISODate(date: Date): string {
     const year = date.getFullYear();
     const month = (date.getMonth() + 1).toString().padStart(2, '0');
@@ -12,12 +15,18 @@ export default async (request: Request): Promise<Response> => {
     let today = new Date();
     let todayISO = formatISODate(today);
 
+    if (!note) {
+        return new Response("Couldn't find note in request", { status: 400 });
+    }
+
     // Step through each line in content and look for checkboxes
     const lines = content.split('\n');
     const newlines : string[] = [];
     for (let line of lines) {
         console.log('line = ' + line);
         let newline = '';
+
+        // Is this a checkbox task?
         if (line.startsWith('- [ ] ')) {
             // Look for the ➕ emoji.  If it is not in line, we need to format the line.
             if (!line.includes('➕')) {

--- a/plugins/community/obsidian-taskify/test.json
+++ b/plugins/community/obsidian-taskify/test.json
@@ -1,0 +1,8 @@
+{
+    "metadata": "some metadata",
+    "note": {
+        "title": "title",
+        "content": "- [ ] This is a task\n- [ ] This is a task with a due date 2024-02-01\n- [ ] This is an Obsidian Task ➕ 2024-01-28 📅 2024-01-29",
+        "source": "source"
+    }
+}

--- a/plugins/community/obsidian-taskify/webserver.ts
+++ b/plugins/community/obsidian-taskify/webserver.ts
@@ -1,0 +1,3 @@
+import { serve } from "https://deno.land/std@0.155.0/http/server.ts";
+import myPlugin from "./index.ts"
+serve(myPlugin);


### PR DESCRIPTION
Hi, I've written a plugin that will step through the content of a note, find any lines with checkboxes that are simple tasks (just checkbox and text), and then convert the line to a task in Obsidian Tasks emoji format.  If a date is included (YYYY-MM-DD format), it is added as a due date.  No matter what, a creation date is added (➕).

Example - 
```
- [ ] This is a task 
- [ ] This is a task with a due date 2024-02-01
- [ ] This is an Obsidian Task ➕ 2024-01-28 📅 2024-01-29
```
becomes:
```
- [ ] This is a task ➕ 2024-01-28
- [ ] This is a task with a due date ➕ 2024-01-28 📅 2024-02-01
- [ ] This is an Obsidian Task ➕ 2024-01-28 📅 2024-01-29
```
